### PR TITLE
BDOG-901: Update to use -r instead of -f for runFromBinary

### DIFF
--- a/src/main/scala/uk/gov/hmrc/ServiceManagerPlugin.scala
+++ b/src/main/scala/uk/gov/hmrc/ServiceManagerPlugin.scala
@@ -115,7 +115,7 @@ class ServiceManagerConfiguration(externalServices: List[ExternalService]) {
   private def runServicesCommand(externalServices: List[ExternalService], runFromBinary: Boolean): Seq[String] = {
     if (externalServices.isEmpty) Seq(s"echo", s"no services required running from runFromBinary $runFromBinary")
     else {
-      val runFromBinaryFlag = if (runFromBinary) List("-f") else Nil
+      val runFromBinaryFlag = if (runFromBinary) List("-r") else Nil
       Seq("sm", "--start") ++ externalServices.map(_.name) ++ List("--appendArgs", "{" + externalServices.map(_.configToString).filter(_.nonEmpty).mkString(",") + "}", "--wait", "240") ++ runFromBinaryFlag
     }
   }


### PR DESCRIPTION
The -f flag looks for snapshot builds, whereas -r looks for release
builds. Since everything that is built by Jenkins is now a release (and
has been for 2 years?) it makes sense to default to this.

Furthermore, the -f will be deprecated in the near future for newer
versions of service-manager.